### PR TITLE
Dynamically changes copyright year in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,7 +943,9 @@
     <footer>
         <div class="container text-center">
             <hr /><br />
-            <p>Copyright &copy; Temple Formula Racing, 2019.</p>
+            <p>Copyright &copy; Temple Formula Racing, 
+                <script type="text/javascript">document.write(new Date().getFullYear());</script>
+            </p>
         </div>
     </footer>
 


### PR DESCRIPTION
The footer is currently out of date, still shows copyright year as 2019. Merging this pull request adds JS to update the footer dynamically.